### PR TITLE
Add .sabermap download button

### DIFF
--- a/details.php
+++ b/details.php
@@ -49,7 +49,7 @@ if(empty($bt[0]["beatname"])){die("<br><br><br><br><br><br><br><br><center><h1>S
 <?php if(!empty($_SESSION["userdb"][0]["id"])){ ?> </a> <?php } ?><br><br>
     <p>
 	<a class="btn btn-default" href="<?php echo 'dl.php?id='.$bt[0]['id']; ?>" role="button" title="For manual installation">Download Zip</a>
-        <a class="btn btn-default" href="<?php echo 'dl.php?id='.$bt[0]['id']; ?>" role="button" title="Automatic installation, requires newest ModInstaller version">Install Sabermap</a>
+        <a class="btn btn-default" href="<?php echo 'dl.php?id='.$bt[0]['id'].'&type=sabermap'; ?>" role="button" title="Automatic installation, requires newest ModInstaller version">Install Sabermap</a>
     </p><p>
 </td>
   </tr>

--- a/details.php
+++ b/details.php
@@ -47,7 +47,10 @@ if(empty($bt[0]["beatname"])){die("<br><br><br><br><br><br><br><br><center><h1>S
   <span class="glyphicon glyphicon-star" aria-hidden="true"></span> Stars <?php echo number_format($bt[0]["upvotes"]); ?>
 </button>
 <?php if(!empty($_SESSION["userdb"][0]["id"])){ ?> </a> <?php } ?><br><br>
-    <p><a class="btn btn-default" href="<?php echo 'dl.php?id='.$bt[0]['id']; ?>" role="button">Download File</a></p><p>
+    <p>
+	<a class="btn btn-default" href="<?php echo 'dl.php?id='.$bt[0]['id']; ?>" role="button" title="For manual installation">Download Zip</a>
+        <a class="btn btn-default" href="<?php echo 'dl.php?id='.$bt[0]['id']; ?>" role="button" title="Automatic installation, requires newest ModInstaller version">Install Sabermap</a>
+    </p><p>
 </td>
   </tr>
 </table>

--- a/dl.php
+++ b/dl.php
@@ -19,6 +19,10 @@ if(empty($m->get($key))){
 $database->update("beats", [ "downloads[+]" => 1],["id" => $data[0]["id"]]);
 $m->set($key, 100, 3600);
 }
+	
+if($_GET["type"] == "sabermap"){
+	header('Content-Disposition: attachment; filename="' . $data[0]["id"] . '.sabermap"');
+}
 
 header("Location: files/" . $data[0]["id"] . ".zip");
 die();

--- a/dl.php
+++ b/dl.php
@@ -21,10 +21,15 @@ $m->set($key, 100, 3600);
 }
 	
 if($_GET["type"] == "sabermap"){
-	header('Content-Disposition: attachment; filename="' . $data[0]["id"] . '.sabermap"');
+    header('Content-type: application/sabermap');
+    header('Content-Disposition: attachment; filename="' . $data[0]["id"] . '.sabermap"');
+} else {
+    header('Content-type: application/zip');
+    header('Content-Disposition: attachment; filename="' . $data[0]["id"] . '.zip"');
 }
 
-header("Location: files/" . $data[0]["id"] . ".zip");
+readfile("files/" . $data[0]["id"] . ".zip");
+	
 die();
 
 }else{


### PR DESCRIPTION
First of all, I have created a pull request on the BeatSaberModInstaller repository: https://github.com/Umbranoxio/BeatSaberModInstaller/pull/1

If the above PR gets accepted, this one would accompany it by adding an "install" button next to the "download" one allowing people to download and automatically open maps as .sabermap files in the Mod Installer. This takes downloading a custom song from fiddling with zip files to a simple one-click process.

(Note: Since .sabermap files are simply renamed .zip files, the only addition to the download script is to set the filename the client uses to a .sabermap extension using a content-disposition header)

Accept this PR only if the mentioned addition to the mod installer is accepted, otherwise it wouldn't make a lot of sense - other than that I'm open for feedback and comments :)

~ Pi